### PR TITLE
Print a soft warning message on the console when the settings.json do…

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -47,7 +47,14 @@ function writeJsonFile(filename, content) {
 }
 
 function readSettingsFromFile() {
-	var settings = readJsonFile('settings.json');
+	try { 
+		var settings = readJsonFile('settings.json');
+	} catch (err) {
+		if (err.code == "ENOENT") {
+			console.log("Could not open settings.json file - it does not exist. Default settings will be used.");	
+			settings = {}
+		}
+	}
 
 	if (settings.port === undefined) {
 		settings.port = 1337;


### PR DESCRIPTION
When the settings.json file does not exist, print a soft warning message to the console. It used to print an exception.

Old behavior: 

```
Reading:  /home/jread/sandbox/flexible-message-board/server/configuration/settings.json
fs.js:549
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/home/jread/sandbox/flexible-message-board/server/configuration/settings.json'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:397:15)
    ....
```

Behavior with this patch: 

```
Reading:  /home/jread/sandbox/flexible-message-board/server/configuration/settings.json
Could not open settings.json file - it does not exist. Default settings will be used.
Declaring Default Routes
Server started on port 1337
```

