### PR TITLE
Revert "Only load .js files as plugins. Vim and other editors create js.swo, …"

### DIFF
--- a/server/PluginManager.js
+++ b/server/PluginManager.js
@@ -7,10 +7,6 @@ function PluginManager(s) {
 		if (err) throw err;
 
 		files.forEach(function(file) {
-			if (!file.endsWith(".js")) {
-				return;
-			}
-
 			var pluginName = file.substring(0, file.length - 3);
 			var pluginInit = require(self.dir + file).initialise(s);
 


### PR DESCRIPTION
Reverts westlan-uk/flexible-message-board#59

/root/fmb/server/PluginManager.js:10
                        if (!file.endsWith(".js")) {
                                  ^
TypeError: Object shoutout.js has no method 'endsWith'
    at /root/fmb/server/PluginManager.js:10:14
    at Array.forEach (native)
    at /root/fmb/server/PluginManager.js:9:9
    at Object.oncomplete (fs.js:108:15)
npm ERR! weird error 8
npm ERR! not ok code 0